### PR TITLE
Add the '%' operator

### DIFF
--- a/src/Named.hs
+++ b/src/Named.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE KindSignatures, DataKinds, FlexibleInstances, FlexibleContexts,
+{-# LANGUAGE TypeInType, DataKinds, FlexibleInstances, FlexibleContexts,
              FunctionalDependencies, TypeFamilies, TypeOperators,
              PatternSynonyms, UndecidableInstances, ConstraintKinds,
              TypeApplications, ScopedTypeVariables, CPP #-}
@@ -101,6 +101,7 @@ module Named
     (!),
     Name(..),
     with,
+    type (%),
 
     -- * Specialized synonyms
     Flag,
@@ -194,6 +195,20 @@ with name a fn = fn ! named name a
 named :: Name name -> a -> Named a name
 named _ = Named
 {-# INLINE named #-}
+
+{- | An infix synonym for `Named` for operator junkies. Provides more concise
+notation and allows specifying parameter name and type in arbitrary
+order:
+
+@
+f :: "param" % Int -> ...
+g :: Int % "param" -> ...
+@
+
+-}
+type family (x :: k1) % (z :: k2) :: Type where
+  a % name = Named a name
+  name % a = Named a name
 
 --------------------------------------------------------------------------------
 --  Do not read further to avoid emotional trauma.

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -41,11 +41,14 @@ test1_6 =
   test1 "str"! #a True
     & with #b False
 
-test2 :: Named Int "x" -> Int
+test2 :: "x" % Int -> Int
 test2 x = unnamed x * 2
 
+test2' :: Int % "x" -> Int
+test2' (Named x) = x * 2
+
 test2_1 :: Int
-test2_1 = test2 ! #x 5 + test2 ! #x 3
+test2_1 = test2 ! #x 5 + test2' ! #x 3
 
 main :: IO ()
 main = do


### PR DESCRIPTION
I decided to go with `%` because it's the only one-character ASCII option that visually resembles the colon (because of the two circles).

closes #5 